### PR TITLE
채팅 알람 배열로 헤더의 알람 기능 추가, 채팅 알람 수 반환하는 함수 생성 외 수정사항

### DIFF
--- a/src/api/signUp.ts
+++ b/src/api/signUp.ts
@@ -57,6 +57,7 @@ const removeAllInfo = () => {
   localStorage.removeItem("profileUrl");
   localStorage.removeItem("showAlert");
   localStorage.setItem("isAuthenticated", "false");
+  localStorage.removeItem("newChat");
 };
 
 // 액세스 토큰 확인하고 재발급 받는 함수

--- a/src/components/chatPage/AppliedChatList.tsx
+++ b/src/components/chatPage/AppliedChatList.tsx
@@ -10,6 +10,7 @@ import {
   chatRoomPostTitleState,
   roomNameState,
 } from "../../recoil/chat/chatState";
+import getAlarmCount from "../../utils/getAlarmCount";
 
 function AppliedChatList() {
   const navigate = useNavigate();
@@ -68,16 +69,23 @@ function AppliedChatList() {
         {chatLists.data.map((chat: any) => (
           <Styled.ChatRoomContainer key={chat.roomId}>
             <Styled.ChatRoomWrapper>
-              <Styled.TitleDateWrapper>
-                <Styled.Title>{chat.postTitle}</Styled.Title>
-                <Styled.Date>
-                  {(chat.lastMessage?.createdAt &&
-                    `작성일 | ${convertDateFormat(
-                      new Date(chat.lastMessage.createdAt)
-                    )}`) ||
-                    null}
-                </Styled.Date>
-              </Styled.TitleDateWrapper>
+              <Styled.TitleDateAlarmWrapper>
+                <Styled.TitleDateWrapper>
+                  <Styled.Title>{chat.postTitle}</Styled.Title>
+                  <Styled.Date>
+                    {(chat.lastMessage?.createdAt &&
+                      `작성일 | ${convertDateFormat(
+                        new Date(chat.lastMessage.createdAt)
+                      )}`) ||
+                      null}
+                  </Styled.Date>
+                </Styled.TitleDateWrapper>
+                <Styled.ChatAlarm hasNewChat={getAlarmCount(chat.roomId)}>
+                  {getAlarmCount(chat.roomId)
+                    ? `${getAlarmCount(chat.roomId)}개`
+                    : null}
+                </Styled.ChatAlarm>
+              </Styled.TitleDateAlarmWrapper>
               <Styled.ChatContentsChatWrapper>
                 {chat.lastMessage ? (
                   <Styled.MessageWrapper>

--- a/src/components/chatPage/ChatListTapComponentStyle.ts
+++ b/src/components/chatPage/ChatListTapComponentStyle.ts
@@ -1,6 +1,11 @@
 // 내가 작성한 게시물 채팅방 list 와 지원한 채팅방 리스트 style
 
-import styled from "styled-components";
+import styled, { css } from "styled-components";
+
+// 채팅 알림 태그 프롭 타입
+type ChatAlarmProp = {
+  hasNewChat?: boolean;
+};
 
 export const Container = styled.div`
   width: 100%;
@@ -20,12 +25,13 @@ export const ChatRoomContainer = styled.div`
   align-items: center;
   justify-content: center;
   margin: 30px 0;
+  padding: 20px;
 `;
 
 export const ChatRoomWrapper = styled.div`
   width: 95%;
   /* border: 1px solid black; */
-  margin: 20px;
+  /* margin: 20px; */
 `;
 
 // 메세지, 메세지 작성자 wrapper
@@ -38,13 +44,21 @@ export const MessageWrapper = styled.div`
   background-color: white;
 `;
 
-// 게시글 제목, 날짜 wrapper
-export const TitleDateWrapper = styled.div`
-  width: 88%;
+// 게시글 제목, 날짜, 채팅 알람 wrapper
+export const TitleDateAlarmWrapper = styled.div`
+  /* width: 88%; */
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  /* margin: 30px 13px; */
+  gap: 22px;
+`;
+
+// 게시글 제목, 날짜 wrapper
+export const TitleDateWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 `;
 
 // 글 제목
@@ -60,6 +74,27 @@ export const Title = styled.div`
 export const Date = styled.div`
   font-size: 12px;
   color: #999;
+  line-height: 19px;
+`;
+
+// 채팅 알림
+export const ChatAlarm = styled.p<ChatAlarmProp>`
+  width: 100px;
+  text-align: right;
+  ${({ hasNewChat }) =>
+    hasNewChat &&
+    css`
+      &::before {
+        content: "";
+        display: inline-block;
+        width: 15px;
+        height: 15px;
+        border-radius: 15px;
+        background: #fb1b1b;
+        margin-right: 8px;
+        margin-bottom: -2px;
+      }
+    `};
 `;
 
 // 대화내용, 대화하기 버튼

--- a/src/components/chatPage/MyPostChatList.tsx
+++ b/src/components/chatPage/MyPostChatList.tsx
@@ -10,6 +10,7 @@ import {
   chatRoomPostTitleState,
   roomNameState,
 } from "../../recoil/chat/chatState";
+import getAlarmCount from "../../utils/getAlarmCount";
 
 function MyPostChatList() {
   const navigate = useNavigate();
@@ -66,16 +67,23 @@ function MyPostChatList() {
       {chatLists.data.map((chat: any) => (
         <Styled.ChatRoomContainer key={chat.roomId}>
           <Styled.ChatRoomWrapper>
-            <Styled.TitleDateWrapper>
-              <Styled.Title>{chat.postTitle}</Styled.Title>
-              <Styled.Date>
-                {(chat.lastMessage?.createdAt &&
-                  `작성일 | ${convertDateFormat(
-                    new Date(chat.lastMessage.createdAt)
-                  )}`) ||
-                  null}
-              </Styled.Date>
-            </Styled.TitleDateWrapper>
+            <Styled.TitleDateAlarmWrapper>
+              <Styled.TitleDateWrapper>
+                <Styled.Title>{chat.postTitle}</Styled.Title>
+                <Styled.Date>
+                  {(chat.lastMessage?.createdAt &&
+                    `작성일 | ${convertDateFormat(
+                      new Date(chat.lastMessage.createdAt)
+                    )}`) ||
+                    null}
+                </Styled.Date>
+              </Styled.TitleDateWrapper>
+              <Styled.ChatAlarm hasNewChat={getAlarmCount(chat.roomId)}>
+                {getAlarmCount(chat.roomId)
+                  ? `${getAlarmCount(chat.roomId)}개`
+                  : null}
+              </Styled.ChatAlarm>
+            </Styled.TitleDateAlarmWrapper>
             <Styled.ChatContentsChatWrapper>
               {chat.lastMessage ? (
                 <Styled.MessageWrapper>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,13 +13,10 @@ import {
   isSearchClicked,
   searchedTitleState,
 } from "../../recoil/filter/filterdPost";
-import hasNewChatState from "../../recoil/chat/alarm";
 
 function Header() {
-  // 채팅 알람 state
-  const [hasNewChat] = useRecoilState(hasNewChatState);
-  // 채팅이 새로 왔는지에 대한 state
-  const [hasNew, setHasNew] = useState(false);
+  // 로컬에 저장된 새로운 채팅 여부 (boolean)
+  const hasNew = localStorage.getItem("hasNewChat");
 
   // 토큰 state
   const accessToken = getAccessToken();
@@ -101,15 +98,13 @@ function Header() {
     navigate("/create-post/step1");
   };
 
+  // 서버로부터 새로운 프로필 이미지 받아오면 업데이트
   useEffect(() => {
     if (profileImg !== "" && profileImg !== null) {
       setUserProfile(() => profileImg);
     }
   }, [profileImg, userProfile]);
 
-  useEffect(() => {
-    setHasNew(() => hasNewChat);
-  }, [hasNewChat]);
   return (
     <st.headerAria>
       <st.DanimTitle>다님</st.DanimTitle>
@@ -132,7 +127,7 @@ function Header() {
               buttonName="chat"
               type="button"
               onClick={handleChatButtonClick}
-              hasNew={hasNew}
+              hasNew={hasNew === "true"}
             >
               <img src="/header/chat.svg" alt="채팅하기" />
             </st.chatAndUserButton>

--- a/src/components/common/commonStyle/HeaderST.ts
+++ b/src/components/common/commonStyle/HeaderST.ts
@@ -88,14 +88,20 @@ const chatAndUserButton = styled.button<CommonStyleButtonProps>`
   height: 34px;
   padding: 0;
   background-color: transparent;
+  position: relative;
   ${({ hasNew }) =>
     hasNew &&
     css`
       &::after {
-        content: "알림!";
+        content: "⚡️";
         display: inline-block;
+        position: absolute;
+        left: 13px;
+        top: -15px;
+        font-size: 35px;
       }
     `}
+
   cursor: pointer;
 `;
 

--- a/src/utils/chatConnect.ts
+++ b/src/utils/chatConnect.ts
@@ -16,17 +16,23 @@ const useChatConnect = (userId: string) => {
       {},
       () => {
         stomp.subscribe(`/sub/alarm/${userId}`, (data: any) => {
+          // 로컬 스토리지 배열 저장은 문자열 그대로 사용
+          localStorage.setItem("chatAlarms", data.body);
+
           // 받아온 데이터가 문자열이므로 JSON 객체로 변환
           const alarmArray = JSON.parse(data.body);
-          // console.log(alarmArray);
-          // 받아온 배열 안의 알람 객체의 value가 0이 아닌게 있으면
-          alarmArray.forEach((chatAlarm: any) => {
-            const alarm = Object.values(chatAlarm);
-            if (alarm[0] !== 0) {
-              return setHasNewChat(() => true);
-            }
-            return null;
-          });
+
+          // alarmLeng이 총 알람의 개수
+          const alarmLeng = alarmArray.length;
+
+          // 총 알람의 개수가 0이 아니면 새로운 채팅 있음
+          if (alarmArray[alarmLeng - 1].sum !== 0) {
+            setHasNewChat(true);
+            localStorage.setItem("hasNewChat", "true");
+          } else {
+            setHasNewChat(false);
+            localStorage.setItem("hasNewChat", "false");
+          }
         });
       },
       // 에러 콜백 함수는 string 또는 Frame 타입의 파라미터를 받아야 함.

--- a/src/utils/getAlarmCount.ts
+++ b/src/utils/getAlarmCount.ts
@@ -1,0 +1,22 @@
+// roomId를 받아서 채팅 알람 배열의 roomId에 해당하는 알람 수 반환하는 함수
+
+const getAlarmCount = (roomId: number) => {
+  // 로컬에 저장된 채팅 알람 배열
+  const stringChatAlarmArray = localStorage.getItem("chatAlarms");
+  const stringRoomId = String(roomId); // includes 메서드 사용하기 위해 문자열 변환
+
+  if (stringChatAlarmArray !== null) {
+    // 문자열을 JSON 객체로 변환
+    const chatAlarmArray = JSON.parse(stringChatAlarmArray);
+    // 배열 안의 객체를 하나의 객체로 변환
+    const mergedObject = Object.assign({}, ...chatAlarmArray); // assign(대상 객체, 출처 객체)-> 츨처 객체를 복사해서 대상객체에게 덮어씌움
+    // 객체 안의 roomId들을 하나의 배열로 변환
+    const roomIdArray = Object.keys(mergedObject); // [31, 36, 45...] 이런 형태임
+    // roomId가 해당 배열에 있는지 검사
+    if (roomIdArray.includes(stringRoomId)) {
+      return mergedObject[stringRoomId];
+    }
+  }
+  return false;
+};
+export default getAlarmCount;


### PR DESCRIPTION
1. 채팅 알람으로 받은 배열 전체는 로컬 스토리지에 저장하고, 배열의 마지막 값인 총 알람 개수로 새로운 채팅이 왔는지에 대한 여부를 boolean 값으로 로컬 스토리지에 저장합니다.
2. 채팅 알람으로 받은 배열 전체를 가지고 특정 roomId에 대한 채팅 알람 수를 반환하는 함수를 생성하였고, 그 함수로 채팅 알람 수를 렌더링하게 수정했습니다.
3. 채팅 알람, 채팅 목록의 알람과 관련된 스타일링 수정했습니다.