### PR TITLE
로그인 토큰 저장 로직 변경으로 인한 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,19 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import { RecoilRoot } from "recoil";
+import { useEffect } from "react";
 import Router from "./router/Router";
 import "./styles/reset.css";
 import "normalize.css";
 import GlobalStyle from "./GlobalStyle";
+import { refreshAccessToken } from "./api/signUp";
 
 const queryclient = new QueryClient();
 
 function App() {
+  // 새로고침 했을때 액세스 토큰 재발급
+  useEffect(() => {
+    refreshAccessToken();
+  }, []);
   return (
     <RecoilRoot>
       <GlobalStyle />

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -5,13 +5,15 @@ import { axiosInstance, getCookie, showError } from "./signUp";
 // 채팅방 입장
 export const chatStart = async (postId: number) => {
   try {
-    const response = await axiosInstance.post(`api/chat/room/${postId}`, null, {
-      headers: {
-        ACCESS_KEY: getCookie("accessToken"),
-      },
-    });
+    // const response = await axiosInstance.post(`api/chat/room/${postId}`, null, {
+    //   headers: {
+    //     ACCESS_KEY: getCookie("accessToken"),
+    //   },
+    // });
+    const response = await axiosInstance.post(`api/chat/room/${postId}`, null);
     return response.data;
   } catch (error: any) {
+    console.log("ㅇㅇ", axiosInstance.defaults.headers);
     if (error.response.status === 401) {
       const { detail } = error.response.data;
       if (detail === "신청하신 나이대에 포함되지않습니다.") {

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,5 +1,5 @@
 import SearchKeyword from "../types/searchType";
-import { axiosInstance } from "./signUp";
+import { axiosInstance, generalInstance, getAccessToken } from "./signUp";
 
 interface FetchSearchParams {
   allKeyword: SearchKeyword;
@@ -42,6 +42,7 @@ export const fetchAllPosts = async ({
 }) => {
   try {
     const response = await axiosInstance.get(
+      // const response = await generalInstance.get(
       `/api/posts/?page=${page}&size=${size}`
     );
     return response.data;

--- a/src/api/signUp.ts
+++ b/src/api/signUp.ts
@@ -5,6 +5,7 @@ import { User, UserInfoForKakao } from "../types/userType";
 // axiosInstace (액세스 토큰 만료시 재발급 받는 인터셉터 있음)
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_APP_URL,
+  withCredentials: true,
 });
 
 // generalInstance (인터셉터 없음)
@@ -185,19 +186,26 @@ export const fetchLogin = async (user: {
       // 웹 소켓 통신에 연결
       // chatConnect();
       // 토큰 및 유저 정보 저장
-      const accessToken = response.headers.access_key;
-      const refreshToken = response.headers.refresh_key;
-      const { id } = response.data.data;
-      const { nickName: nickname } = response.data.data;
-      const { myPageImageUrl: profileUrl } = response.data.data;
+      // const accessToken = response.headers.access_key;
+      // const refreshToken = response.headers.refresh_key;
+
+      // API 요청하는 콜마다 헤더에 accessToken 담아 보내도록 설정
+      const {
+        accessToken,
+        id,
+        nickName: nickname,
+        myPageImageUrl: profileUrl,
+      } = response.data.data;
+      axiosInstance.defaults.headers.common.ACCESS_KEY = `${accessToken}`;
+      console.log(axiosInstance.defaults.headers.common);
       localStorage.setItem("nickname", nickname);
       localStorage.setItem("profileUrl", profileUrl);
       localStorage.setItem("id", id);
       localStorage.setItem("isAuthenticated", "true");
-      if (accessToken && refreshToken) {
-        setCookie("accessToken", accessToken, 1);
-        setCookie("refreshToken", refreshToken, 14);
-      }
+      // if (accessToken && refreshToken) {
+      //   setCookie("accessToken", accessToken, 1);
+      //   setCookie("refreshToken", refreshToken, 14);
+      // }
     }
     return response;
   } catch (err: any) {

--- a/src/api/signUp.ts
+++ b/src/api/signUp.ts
@@ -9,9 +9,14 @@ export const axiosInstance = axios.create({
 });
 
 // generalInstance (인터셉터 없음)
-// export const generalInstance = axios.create({
-//   baseURL: import.meta.env.VITE_APP_URL,
-// });
+export const generalInstance = axios.create({
+  baseURL: import.meta.env.VITE_APP_URL,
+});
+
+const refreshInstance = axios.create({
+  baseURL: import.meta.env.VITE_APP_URL,
+  timeout: 1000,
+});
 
 // 에러 콘솔 출력 함수
 export function showError(error: any) {
@@ -63,37 +68,37 @@ const removeAllInfo = () => {
 };
 
 // 액세스 토큰 확인하고 재발급 받는 함수
-export const checkAccessToken = async () => {
-  const token = getAccessToken();
+// export const checkAccessToken = async () => {
+//   const token = getAccessToken();
 
-  if (token) {
-    return "accessToken 재발급 완료";
-  }
-  // 액세스 토큰이 만료된 경우
-  if (token === null || token === "") {
-    const refreshToken = getRefreshToken();
-    if (refreshToken) {
-      try {
-        const response = await axiosInstance.get("/api/user/refreshToken", {
-          headers: {
-            REFRESH_KEY: refreshToken,
-          },
-        });
-        const newAccessToken = response.headers.access_key;
+//   if (token) {
+//     return "accessToken 재발급 완료";
+//   }
+//   // 액세스 토큰이 만료된 경우
+//   if (token === null || token === "") {
+//     const refreshToken = getRefreshToken();
+//     if (refreshToken) {
+//       try {
+//         const response = await axiosInstance.get("/api/user/refreshToken", {
+//           headers: {
+//             REFRESH_KEY: refreshToken,
+//           },
+//         });
+//         const newAccessToken = response.headers.access_key;
 
-        // 새롭게 발급 받은 액세스 토큰을 쿠키에 저장
-        setCookie("accessToken", newAccessToken, 1);
+//         // 새롭게 발급 받은 액세스 토큰을 쿠키에 저장
+//         setCookie("accessToken", newAccessToken, 1);
 
-        return newAccessToken;
-      } catch (error) {
-        return error;
-      }
-    }
-  }
-  return null;
-};
+//         return newAccessToken;
+//       } catch (error) {
+//         return error;
+//       }
+//     }
+//   }
+//   return null;
+// };
 
-// 액세스 토큰 만료 확인하는 인터셉터
+// 액세스 재발급 받는 인터셉터
 // axiosInstance.interceptors.request.use(
 //   async (config) => {
 //     const token = await checkAccessToken();
@@ -109,6 +114,34 @@ export const checkAccessToken = async () => {
 //   },
 //   (error) => Promise.reject(error)
 // );
+export const refreshAccessToken = async () => {
+  try {
+    // 토큰 갱신 요청은 refreshInstance를 사용하여 보내기
+    const response = await refreshInstance.get("/api/user/refreshToken");
+    console.log("여기서 리스폰스", response);
+    const { accessToken } = response.data.data;
+    axiosInstance.defaults.headers.common.ACCESS_KEY = `${accessToken}`;
+    return accessToken;
+  } catch (err: any) {
+    console.log("여기서 에러", err);
+    const errMessage = err.response.data.detail || err.message;
+    return errMessage;
+  }
+};
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest.retryAttempted) {
+      originalRequest.retryAttempted = true;
+      const accessToken = await refreshAccessToken(); // 새 액세스 토큰을 가져오는 함수
+      originalRequest.headers.ACCESS_KEY = `${accessToken}`;
+      return axiosInstance(originalRequest);
+    }
+    return Promise.reject(error);
+  }
+);
 
 // 회원가입 - 아이디 중복검사
 export const fetchCheckId = async (id: string) => {
@@ -178,7 +211,7 @@ export const fetchLogin = async (user: {
   password: string;
 }) => {
   try {
-    const response = await axiosInstance.post("/api/user/login", user);
+    const response = await generalInstance.post("/api/user/login", user);
     if (response.data.status === 500) {
       throw response.data;
     }
@@ -196,8 +229,8 @@ export const fetchLogin = async (user: {
         nickName: nickname,
         myPageImageUrl: profileUrl,
       } = response.data.data;
+      // axiosInstance.defaults.headers.common.ACCESS_KEY = `Bearer ${accessToken}`;
       axiosInstance.defaults.headers.common.ACCESS_KEY = `${accessToken}`;
-      console.log(axiosInstance.defaults.headers.common);
       localStorage.setItem("nickname", nickname);
       localStorage.setItem("profileUrl", profileUrl);
       localStorage.setItem("id", id);

--- a/src/api/userInfo.ts
+++ b/src/api/userInfo.ts
@@ -1,24 +1,23 @@
 import { axiosInstance, getAccessToken } from "./signUp";
 
-
 // 에러 콘솔 출력 함수
 export function showError(error: any) {
   console.log("여기서 error 발생", error);
 }
 
-
 // 유저 정보 가져오기(비동기 통신함수)
 export const fecthUserInfo = async (id: string) => {
   try {
-    const accessToken = getAccessToken();
-    const response = await axiosInstance.get(`/api/user/${id}/info`, {
-    headers: {
-          ACCESS_KEY: accessToken,
-        },
-      });
-    
-    return response.data.data
+    // const accessToken = getAccessToken();
+    // const response = await axiosInstance.get(`/api/user/${id}/info`, {
+    // headers: {
+    //       ACCESS_KEY: accessToken,
+    //     },
+    //   });
+    const response = await axiosInstance.get(`/api/user/${id}/info`);
+    return response.data.data;
   } catch (err: any) {
+    console.log("ㅇㅇ", axiosInstance.defaults.headers.common);
     const errMessage = err.response.data.detail || err.message;
     return errMessage;
   }
@@ -26,58 +25,52 @@ export const fecthUserInfo = async (id: string) => {
 
 // 리뷰 가져오기
 export const fecthReviews = async (id: string) => {
-    try {
-      const accessToken = getAccessToken();
-      const response = await axiosInstance.get(`/api/user/${id}/review`, {
-      headers: {
-            ACCESS_KEY: accessToken,
-          },
-        });
-      
-      return response.data.data
-    } catch (err: any) {
-      const errMessage = err.response.data.detail || err.message;
-      return errMessage;
-    }
-  };
-  
+  try {
+    // const accessToken = getAccessToken();
+    // const response = await axiosInstance.get(`/api/user/${id}/review`, {
+    //   headers: {
+    //     ACCESS_KEY: accessToken,
+    //   },
+    // });
+    const response = await axiosInstance.get(`/api/user/${id}/review`);
+    return response.data.data;
+  } catch (err: any) {
+    const errMessage = err.response.data.detail || err.message;
+    return errMessage;
+  }
+};
+
 // 게시글 가져오기
 export const fecthPosts = async (id: string) => {
-    try {
-      const accessToken = getAccessToken();
-      const response = await axiosInstance.get(`/api/user/${id}/posts`, {
-      headers: {
-            ACCESS_KEY: accessToken,
-          },
-        });
-      return response.data.data
-    } catch (err: any) {
-      const errMessage = err.response.data.detail || err.message;
-      return errMessage;
-    }
-  };
-  
-
-  
+  try {
+    // const accessToken = getAccessToken();
+    // const response = await axiosInstance.get(`/api/user/${id}/posts`, {
+    //   headers: {
+    //     ACCESS_KEY: accessToken,
+    //   },
+    // });
+    const response = await axiosInstance.get(`/api/user/${id}/posts`);
+    return response.data.data;
+  } catch (err: any) {
+    const errMessage = err.response.data.detail || err.message;
+    return errMessage;
+  }
+};
 
 // 내 정보 수정?
 export const fetchMyInfo = async (id: any, userInfo: any) => {
-    try {
-      const user = new FormData();
-      Object.keys(userInfo).forEach(key=>user.append(key, userInfo[key]))
-      const accessToken = getAccessToken();
-      const response = await axiosInstance.put(`/api/user/${id}/myInfo`, user, {
-        headers: {
-          ACCESS_KEY: accessToken,
-        },
-      });
-      return response.data;
-  
-    } catch (error: any) {
-      const errorMessage = error.response?.data?.detail || error.message;
-      return errorMessage;
-    }
-  };
-
-  
-  
+  try {
+    const user = new FormData();
+    Object.keys(userInfo).forEach((key) => user.append(key, userInfo[key]));
+    const accessToken = getAccessToken();
+    const response = await axiosInstance.put(`/api/user/${id}/myInfo`, user, {
+      headers: {
+        ACCESS_KEY: accessToken,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    const errorMessage = error.response?.data?.detail || error.message;
+    return errorMessage;
+  }
+};

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -29,10 +29,10 @@ function Header() {
   const userId = localStorage.getItem("id");
 
   // 토큰 state
-  const accessToken = getAccessToken();
-  const refreshToken = getRefreshToken();
-  const [userAccessCookie, setUserAccessCookie] = useState(accessToken);
-  const [userRefreshCookie, setUserRefreshCookie] = useState(refreshToken);
+  // const accessToken = getAccessToken();
+  // const refreshToken = getRefreshToken();
+  // const [userAccessCookie, setUserAccessCookie] = useState(accessToken);
+  // const [userRefreshCookie, setUserRefreshCookie] = useState(refreshToken);
   const [, setLoginUserId] = useRecoilState(loginUserIdState);
 
   // 메인페이지에서 관리하는 검색 state
@@ -59,8 +59,8 @@ function Header() {
         text: "로그아웃이 완료되었습니다.",
         confirmButtonColor: "#A3BF3B",
       });
-      setUserAccessCookie(null);
-      setUserRefreshCookie(null);
+      // setUserAccessCookie(null);
+      // setUserRefreshCookie(null);
       setLoginUserId("");
       return navigate("/");
     },
@@ -138,7 +138,8 @@ function Header() {
           src="/header/danimLogo.svg"
           alt="다님 로고"
         />
-        {userAccessCookie || userRefreshCookie ? (
+        {/* {userAccessCookie || userRefreshCookie ? ( */}
+        {userId ? (
           <st.ButtonContainer>
             <st.CommonStyleButton
               buttonName="post"

--- a/src/router/PrivateRouter.tsx
+++ b/src/router/PrivateRouter.tsx
@@ -35,9 +35,9 @@
 //     <Navigate to="/" />
 //   );
 // }
-import { useEffect } from "react";
+// import { useEffect } from "react";
 import { Navigate, Outlet } from "react-router-dom";
-import { checkAccessToken } from "../api/signUp";
+// import { checkAccessToken } from "../api/signUp";
 
 interface PrivateRouteProps {
   authentication: boolean;
@@ -47,9 +47,9 @@ export default function PrivateRoute({
   authentication,
 }: PrivateRouteProps): React.ReactElement | null {
   // 컴포넌트 렌더링 시 액세스 토큰 만료 확인 및 재발급
-  useEffect(() => {
-    checkAccessToken();
-  }, []);
+  // useEffect(() => {
+  //   checkAccessToken();
+  // }, []);
 
   /**
    * 로그인 했는지 여부


### PR DESCRIPTION
1. 로그인 토큰 저장 로직을 기존의 쿠키 저장 방식에서 'access-token : 따로 저장하지 않고 instance의 Header로 설정 / refresh-token : httpOnly 설정으로 서버에서만 관리'로 변경했습니다.